### PR TITLE
Update font-weight for Google Font

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
     <title>Ordino</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
-    <link href="//fonts.googleapis.com/css?family=Yantramanav:500,400,300" rel="stylesheet" type="text/css">
+    <link href="//fonts.googleapis.com/css?family=Yantramanav:700,500,400" rel="stylesheet" type="text/css">
     <link href="./style.css?cache-bust=${Date.now()}" rel="stylesheet" type="text/css">
     <link rel="icon" href="${require('phovea_ui/src/assets/favicon.png')}">
     <script src="//cdn.polyfill.io/v2/polyfill.min.js"></script>


### PR DESCRIPTION
Set default font-weight of Google fonts to avoid ugly interpolation.
Default weights are documented here https://css-tricks.com/almanac/properties/f/font-weight/

See also https://github.com/phovea/phovea_server/pull/56

With `fonts.googleapis.com/css?family=Yantramanav:500,400,300`

![grafik](https://user-images.githubusercontent.com/5851088/29173264-106fb1ca-7de3-11e7-9e38-77fe3b6ff95d.png)

With `fonts.googleapis.com/css?family=Yantramanav:700,500,400`

![grafik](https://user-images.githubusercontent.com/5851088/29173333-3c33a19a-7de3-11e7-9e4a-6732e19b0559.png)
