### PR TITLE
Extract welcome view to extension and adapt welcome content

### DIFF
--- a/.yo-rc.json
+++ b/.yo-rc.json
@@ -25,7 +25,14 @@
       "node_modules.*(d3|bootstrap|jquery|select2)",
       "((node_modules.*popper)|lineupjs|lineupengine|tdp_core)"
     ],
-    "extensions": [],
+    "extensions": [
+      {
+        "type": "ordinoWelcomeView",
+        "id": "ordinoWelcomeView",
+        "module": "WelcomeView",
+        "extras": {}
+      }
+    ],
     "sextensions": [],
     "libraries": [
       "scrollTo",

--- a/phovea.js
+++ b/phovea.js
@@ -60,6 +60,9 @@ module.exports = function (registry) {
     priority: 95
   });
 
+  registry.push('ordinoWelcomeView', 'ordinoWelcomeView', function() { return import('./src/WelcomeView'); }, {
+    priority: 10
+  });
   // generator-phovea:end
 };
 

--- a/src/WelcomeView.ts
+++ b/src/WelcomeView.ts
@@ -1,0 +1,19 @@
+import * as d3 from 'd3';
+
+import WelcomeViewTemplate from 'html-loader!./welcome_view.html';
+
+export interface IWelcomeView {
+  build();
+}
+
+export default class WelcomeView implements IWelcomeView {
+  private $node: d3.Selection<any>;
+
+  constructor(parent: HTMLElement) {
+    this.$node = d3.select(parent);
+  }
+
+  build() {
+    this.$node.html(WelcomeViewTemplate);
+  }
+}

--- a/src/welcome_view.html
+++ b/src/welcome_view.html
@@ -7,10 +7,10 @@
         genes, cell lines, and tissue samples based on a rich set of experimental and metadata.
       </p>
       <p>
-        Ordino contains data from
+        Ordino contains data from BI cell line collection,
         <a href="https://cancergenome.nih.gov" rel="noopener" target="_blank">The Cancer Genome Atlas (TCGA)</a>,
-        the <a href="https://portals.broadinstitute.org/ccle" rel="noopener" target="_blank">Cancer Cell Line Encyclopedia (CCLE)</a>,<br>
-        as well as two depletion screen data sets from
+        the <a href="https://www.gtexportal.org/" rel="noopener" target="_blank"> Genotype-Tissue Expression (GTEx) project</a>,<br>
+        as well as CRISPR / RNAi loss-of-function screen data sets from
         <a href="https://doi.org/10.1016/j.cell.2017.07.005" rel="noopener" target="_blank">McDonald et al. (Cell 2017)</a> and
         <a href="https://doi.org/10.1038/ng.3984" rel="noopener" target="_blank">Meyers et al. (Nat. Genet. 2017)</a>.
       </p>


### PR DESCRIPTION
Closes Caleydo/tdp_bi_bioinfodb#840

* Extracted the welcome view to an extension
* If multiple welcome view extensions are found (e.g., for Ordino Public) it will show the view with the highest priority


