### PR TITLE
trigger an optional view update after the mode animation change

### DIFF
--- a/src/internal/ViewWrapper.ts
+++ b/src/internal/ViewWrapper.ts
@@ -26,13 +26,13 @@ import {
   isSameSelection,
   IView,
   IViewContext,
-  IViewPluginDesc,
   matchLength,
   showAsSmallMultiple,
   toViewPluginDesc
 } from 'tdp_core/src/views';
 import {resolveImmediately} from 'phovea_core/src/internal/promise';
 import {groupByCategory} from 'tdp_core/src/views/findViews';
+import {MODE_ANIMATION_TIME} from './constants';
 
 function generate_hash(desc: IPluginDesc, selection: ISelection) {
   const s = (selection.idtype ? selection.idtype.id : '') + 'r' + (selection.range.toString());
@@ -296,10 +296,23 @@ export default class ViewWrapper extends EventHandler {
     // trigger modeChanged
     this.instance.modeChanged(mode);
 
+    this.updateAfterAnimation();
+
     // on focus view scroll into view
     if (mode === EViewMode.FOCUS) {
       this.scrollIntoView();
     }
+  }
+
+  private updateAfterAnimation() {
+    if (!this.instance || typeof (<any>this.instance).update !== 'function') {
+      return;
+    }
+    setTimeout(() => {
+      if ((<any>this.instance) && typeof (<any>this.instance).update === 'function') {
+        (<any>this.instance).update();
+      }
+    }, MODE_ANIMATION_TIME);
   }
 
   private scrollIntoView() {

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -12,3 +12,6 @@
  * @type {string}
  */
 export const SESSION_KEY_NEW_ENTRY_POINT = 'ordinoNewEntryPoint';
+
+// see src/styles/_targid.scss + 100ms delay
+export const MODE_ANIMATION_TIME = 500 + 100;

--- a/src/styles/_targid.scss
+++ b/src/styles/_targid.scss
@@ -212,6 +212,10 @@ nav.mainNavi {
 }
 
 
+// see also src/internal/constants
+$mode-animation-time: 500ms;
+
+
 div.targid {
   flex: 1;
 
@@ -234,7 +238,7 @@ div.targid {
 
     width: 50%;
     overflow: hidden;
-    transition: width 0.5s ease;
+    transition: width $mode-animation-time ease;
 
     // first view should have width:100%
     &:nth-child(2):last-child {


### PR DESCRIPTION
 (focus, context, ...) is done

fixes the problem of invisible columns since lineup early computes the available width before the animation has finished