### PR TITLE
Add matomo tracking from tdp_matomo

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "jquery.scrollto": "2.1.2",
     "@types/jquery": "2.0.33",
     "jquery": "3.1.1",
-    "tdp_core": "github:datavisyn/tdp_core#develop"
+    "tdp_core": "github:datavisyn/tdp_core#develop",
+    "tdp_matomo": "github:datavisyn/tdp_matomo#develop"
   }
 }

--- a/src/Ordino.ts
+++ b/src/Ordino.ts
@@ -30,11 +30,11 @@ export default class Ordino extends ATDPApplication<OrdinoApp> {
       prefix: 'ordino',
       name: 'Ordino'
     }, options));
+
+    this.matomoTracking(); // enable matomo tracking before createApp()
   }
 
   protected createApp(graph: ProvenanceGraph, manager: CLUEGraphManager, main: HTMLElement) {
-    this.matomoTracking();
-
     main.classList.add('targid');
     const startMenuNode = main.ownerDocument.createElement('div');
     startMenuNode.classList.add('startMenu');


### PR DESCRIPTION
* Add [tdp_matomo](https://github.com/datavisyn/tdp_matomo) as dependency
* Configure Ordino-specific tracking actions for Matomo

**Note:** Requires a valid URL + site id to a Matomo backend in the config.json!
The tracking is disabled (even though this function is called) until a valid URL is set in the config.json.