### PR TITLE
Use `npm-force-resolutions` to pin `@types/react` in sub-dependencies to v17.0.44

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
           name: Install npm dependencies
           command: npm install
       - run:
+          name: Patch npm dependencies in package-lock.json
+          command: npx npm-force-resolutions
+      - run:
           name: Remove npm dependencies installed from git repositories (avoid caching of old commits)
           command: |
             (grep -l '._resolved.: .\(git[^:]*\|bitbucket\):' ./node_modules/*/package.json || true) | xargs -r dirname | xargs -r rm -rf

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "release:patch": "npm version patch && npm publish && git push --follow-tags",
     "predist": "npm run build && npm run docs",
     "dist": "mkdir lib && cd dist && tar cvzf ../lib/ordino.tar.gz *",
-    "preinstall": "npx npm-force-resolutions"
+    "preinstall": "npm-force-resolutions"
   },
   "devDependencies": {
     "@types/bootstrap": "~5.0.15",
@@ -79,6 +79,7 @@
     "identity-obj-proxy": "~3.0.0",
     "jest": "~27.5.1",
     "jest-raw-loader": "~1.0.1",
+    "npm-force-resolutions": "0.0.10",
     "prettier": "^2.5.1",
     "rimraf": "~3.0.2",
     "shx": "~0.3.3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "identity-obj-proxy": "~3.0.0",
     "jest": "~27.5.1",
     "jest-raw-loader": "~1.0.1",
-    "npm-force-resolutions": "0.0.10",
     "prettier": "^2.5.1",
     "rimraf": "~3.0.2",
     "shx": "~0.3.3",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "release:minor": "npm version minor && npm publish && git push --follow-tags",
     "release:patch": "npm version patch && npm publish && git push --follow-tags",
     "predist": "npm run build && npm run docs",
-    "dist": "mkdir lib && cd dist && tar cvzf ../lib/ordino.tar.gz *",
-    "preinstall": "npm-force-resolutions"
+    "dist": "mkdir lib && cd dist && tar cvzf ../lib/ordino.tar.gz *"
   },
   "devDependencies": {
     "@types/bootstrap": "~5.0.15",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "release:minor": "npm version minor && npm publish && git push --follow-tags",
     "release:patch": "npm version patch && npm publish && git push --follow-tags",
     "predist": "npm run build && npm run docs",
-    "dist": "mkdir lib && cd dist && tar cvzf ../lib/ordino.tar.gz *"
+    "dist": "mkdir lib && cd dist && tar cvzf ../lib/ordino.tar.gz *",
+    "preinstall": "npx npm-force-resolutions"
   },
   "devDependencies": {
     "@types/bootstrap": "~5.0.15",
@@ -114,5 +115,8 @@
     "react-virtualized": "^9.22.3",
     "tdp_core": "github:datavisyn/tdp_core#ordino-2.0",
     "tdp_comments": "github:datavisyn/tdp_comments#develop"
+  },
+  "resolutions": {
+    "@types/react": "17.0.44"
   }
 }


### PR DESCRIPTION
Closes datavisyn/reprovisyn#314

### Summary

* Add [`npm-force-resolutions`](https://www.npmjs.com/package/npm-force-resolutions) script to CircleCI
   * Patches the package-lock.json from the first `npm install` with the pinned versions defined in the `resolutions` of the package.json
   * Requires another `npm install` after patching the package-lock.json
* Pin `@types/react` to v17.0.44 in the `resolutions` of the package.json
   * Version is equal to the previous successful build and before the React 18 release