### PR TITLE
Update react-intersection-observer to version 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "react-dom": "^16.13.0",
     "react-dropzone": "^11.3.1",
     "react-highlight-words": "^0.17.0",
-    "react-intersection-observer": "^8.31.1",
+    "react-intersection-observer": "^9.0.0",
     "react-router-dom": "^5.2.0",
     "react-select": "^4.1.0",
     "react-select-async-paginate": "^0.5.3",


### PR DESCRIPTION
This pull request was created using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It bumps react-intersection-observer to version 9.0.0.

<strong>Sign up your project [here](https://jsfix.live/scanner) to receive notifications about other packages updates JSFIX can help with.</strong>

***

<h3> Pull request details</h3>

<details><summary>Additional details</summary><blockquote class="pr-blockquote"><details>
<summary>Breaking changes where JSFIX found that there were no occurrences.</summary>

* Removed the default export of the InView component. Use the named InView import instead
</details>

</blockquote></details>

***

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.